### PR TITLE
abi splits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run:
           name: Download Dependencies
-          command: ./gradlew androidDependencies
+          command: ./gradlew androidDependencies -Pci
 
       - save_cache:
           name: Save Cache
@@ -40,12 +40,12 @@ jobs:
 
       - run:
           name: Run Lint
-          command: ./gradlew lint
+          command: ./gradlew lint -Pci
 
       - run:
           name: Run Ktlint
-          command: ./gradlew ktlintCheck
+          command: ./gradlew ktlintCheck -Pci
 
       - run:
           name: Run Unit Tests
-          command: ./gradlew test
+          command: ./gradlew test -Pci

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: "androidx.navigation.safeargs"
 
 android {
     compileSdkVersion 29
-    
+
     defaultConfig {
         applicationId "io.zluan.logoswap"
         minSdkVersion 21
@@ -35,6 +35,17 @@ android {
             java.srcDir sharedTestDir
         }
     }
+    splits {
+        abi {
+            enable true
+            reset()
+            if (rootProject.ext.ci || gradle.startParameter.taskNames.any { it.contains('release') }) {
+                include 'armeabi', 'armeabi-v7a', 'armeabi-v8a', 'mips', 'mips64', 'x86', 'x86_64'
+            } else {
+                include 'x86_64'
+            }
+        }
+    }
     // Necessary for Robolectric unit tests
     testOptions {
         unitTests {
@@ -48,7 +59,7 @@ dependencies {
 
     // Kotlin
     implementation 'androidx.core:core-ktx:1.1.0'
-    implementation"org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0'
 
     // App compat

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.3.50'
     ext.java_version = JavaVersion.VERSION_1_8
+    ext.ci = rootProject.hasProperty('ci')
     repositories {
         google()
         gradlePluginPortal()


### PR DESCRIPTION
@zhaonian 
Closes #20 

Before:
```
$ find . -iname "*.apk" | xargs du -h
 76M	./app/build/outputs/apk/release/app-release-unsigned.apk
 84M	./app/build/outputs/apk/debug/app-debug.apk
```
After(CI and release builds):
```
$ find . -iname "*.apk" | xargs du -h
 76M	./app/build/outputs/apk/release/app-release-unsigned.apk
9.7M	./app/build/outputs/apk/debug/app-armeabi-debug.apk
 12M	./app/build/outputs/apk/debug/app-mips-debug.apk
 13M	./app/build/outputs/apk/debug/app-mips64-debug.apk
9.8M	./app/build/outputs/apk/debug/app-armeabi-v7a-debug.apk
 31M	./app/build/outputs/apk/debug/app-x86_64-debug.apk
 22M	./app/build/outputs/apk/debug/app-x86-debug.apk
```
After(debug builds):
```
$ find . -iname "*.apk" | xargs du -h
 31M	./app/build/outputs/apk/debug/app-x86_64-debug.apk
```